### PR TITLE
User story5

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -5,6 +5,7 @@ class SheltersController < ApplicationController
 
   def show
     @shelter = Shelter.find(params[:id])
+
   end
 
   def new
@@ -12,16 +13,33 @@ class SheltersController < ApplicationController
 
   def create
     new_shelter = Shelter.create(shelter_params)
-   redirect_to "/shelters"
+    redirect_to "/shelters"
   end
 
+  def edit
+  
+    @shelter_id = params[:id]
+    # @shelter_name = params[:name]
+    # @shelter_address = params[:address]
+    # @shelter_city = params[:city]
+    # @shelter_state = params[:state]
+    # @shelter_zipcode = params[:zipcode]
+  end
+
+  def update
+
+    shelter = Shelter.find(params[:id])
+    shelter.update(shelter_params)
+    # shelter.update(@shelter_address)
+    # shelter.update(@shelter_city)
+    # shelter.update(@shelter_state)
+    # shelter.update(@shelter_zipcode)
+   redirect_to "/shelters/#{shelter.id}"
+  end
   private
 
   def shelter_params
-    params.permit(:name)
-  #   params.permit(:address)
-  #   params.permit(:city)
-  #   params.permit(:state)
-  #   params.permit(:zipcode)
+    params.permit(:name, :address, :city, :state, :zipcode)
+
   end
 end

--- a/app/views/shelters/edit.html.erb
+++ b/app/views/shelters/edit.html.erb
@@ -1,0 +1,15 @@
+<h1>Edit Shelter</h1>
+
+<%= form_tag "/shelters/#{@shelter_id}", method: :put do %>
+  <%= label_tag :name %>
+  <%= text_field_tag :name %>
+  <%= label_tag :address %>
+  <%= text_field_tag :address %>
+  <%= label_tag :city %>
+  <%= text_field_tag :city %>
+  <%= label_tag :state %>
+  <%= text_field_tag :state %>
+  <%= label_tag :zipcode %>
+  <%= text_field_tag :zipcode %>
+  <%= submit_tag "Submit Shelter Updates" %>
+<% end %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -3,3 +3,5 @@
   <h2><%= @shelter.city %></h2>
   <h2><%= @shelter.state %></h2>
   <h2><%= @shelter.zipcode %></h2>
+
+<%= link_to "Update Shelter", "/shelters/#{@shelter.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,9 @@ Rails.application.routes.draw do
   get '/shelters', to: 'shelters#index'
   get '/shelters/new', to: 'shelters#new'
   get '/shelters/:id', to: 'shelters#show'
-
   post '/shelters', to: 'shelters#create'
+  get '/shelters/:id/edit', to: 'shelters#edit'
 
+  put '/shelters/:id', to: 'shelters#update'
 
 end

--- a/spec/features/shelters/user_can_update_shelter_from_show_page_spec.rb
+++ b/spec/features/shelters/user_can_update_shelter_from_show_page_spec.rb
@@ -1,0 +1,30 @@
+
+
+require 'rails_helper'
+
+RSpec.describe "Shelter Update", type: :feature do
+  it "Can click update link on show page, see shelter/:id/edit, make changes, and see those changes on show page" do
+    shelter_1 = Shelter.create(name:'Good Shelter', address: '1 wagon rd.', city: 'Denver', state: 'CO', zipcode: '80207')
+
+    shelter_2 = Shelter.create(name:'Very Good Shelter', address: '32 mountain rd.', city: 'San Diego', state: 'CA', zipcode: '93567')
+
+    visit "shelter/#{shelter_1.id}"
+    click_link("Update Shelter")
+    expect(current_path).to eq("/shelters/#{shelter_1.id}/edit")
+
+    fill_in :name, with: "Shelter Shack"
+    fill_in :address, with: 'Broadway'
+    fill_in :city, with: 'Austin'
+    fill_in :state, with: 'TX'
+    fill_in :zipcode, with: '12346'
+    click_button("Submit Shelter Updates")
+
+    expect(current_path).to eq("/shelters/#{shelter_1.id}")
+    expect(page).to have_content("Shelter Shack")
+    expect(page).to have_content('Broadway')
+    expect(page).to have_content('Austin')
+    expect(page).to have_content('TX')
+    expect(page).to have_content('12346')
+
+  end
+end

--- a/spec/features/shelters/user_can_update_shelter_from_show_page_spec.rb
+++ b/spec/features/shelters/user_can_update_shelter_from_show_page_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Shelter Update", type: :feature do
 
     shelter_2 = Shelter.create(name:'Very Good Shelter', address: '32 mountain rd.', city: 'San Diego', state: 'CA', zipcode: '93567')
 
-    visit "shelter/#{shelter_1.id}"
+    visit "shelters/#{shelter_1.id}"
     click_link("Update Shelter")
     expect(current_path).to eq("/shelters/#{shelter_1.id}/edit")
 


### PR DESCRIPTION

As a visitor
When I visit a shelter show page
Then I see a link to update the shelter "Update Shelter"
When I click the link "Update Shelter"
Then I am taken to '/shelters/:id/edit' where I  see a form to edit the shelter's data including:
- name
- address
- city
- state
- zip
When I fill out the form with updated information
And I click the button to submit the form
Then a `PATCH` request is sent to '/shelters/:id',
the shelter's info is updated,
and I am redirected to the Shelter's Show page where I see the shelter's updated info