### PR TITLE
User story6

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -26,6 +26,12 @@ class SheltersController < ApplicationController
     shelter.update(shelter_params)
    redirect_to "/shelters/#{shelter.id}"
   end
+
+  def destroy
+    Shelter.destroy(params[:id])
+   redirect_to "/shelters"
+  end
+
   private
 
   def shelter_params

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -17,23 +17,13 @@ class SheltersController < ApplicationController
   end
 
   def edit
-  
     @shelter_id = params[:id]
-    # @shelter_name = params[:name]
-    # @shelter_address = params[:address]
-    # @shelter_city = params[:city]
-    # @shelter_state = params[:state]
-    # @shelter_zipcode = params[:zipcode]
   end
 
   def update
 
     shelter = Shelter.find(params[:id])
     shelter.update(shelter_params)
-    # shelter.update(@shelter_address)
-    # shelter.update(@shelter_city)
-    # shelter.update(@shelter_state)
-    # shelter.update(@shelter_zipcode)
    redirect_to "/shelters/#{shelter.id}"
   end
   private

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -5,3 +5,4 @@
   <h2><%= @shelter.zipcode %></h2>
 
 <%= link_to "Update Shelter", "/shelters/#{@shelter.id}/edit" %>
+<%= link_to "Delete Shelter", "/shelters/#{@shelter.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
 
   put '/shelters/:id', to: 'shelters#update'
 
+  delete '/shelters/:id', to: 'shelters#destroy'
+
 end

--- a/spec/features/shelters/shelter_delete_spec.rb
+++ b/spec/features/shelters/shelter_delete_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Shelter Delete", type: :feature do
+  it "On shelter show page, click link to delete shelter, return to shelter index, see shelter missing" do
+      shelter_1 = Shelter.create(name:'Good Shelter', address: '1 wagon rd.', city: 'Denver', state: 'CO', zipcode: '80207')
+
+      shelter_2 = Shelter.create(name:'Very Good Shelter', address: '32 mountain rd.', city: 'San Diego', state: 'CA', zipcode: '93567')
+
+      visit "shelters/#{shelter_1.id}"
+      click_link("Delete Shelter")
+      expect(current_path).to eq("/shelters")
+
+      expect(page).to_not have_content("Good Shelter")
+      expect(page).to have_content("Very Good Shelter")
+
+  end
+end
+# As a visitor
+# When I visit a shelter show page
+# Then I see a link to delete the shelter
+# When I click the link "Delete Shelter"
+# Then a 'DELETE' request is sent to '/shelters/:id',
+# the shelter is deleted,
+# and I am redirected to the shelter index page where I no longer see this shelter

--- a/spec/features/shelters/shelter_delete_spec.rb
+++ b/spec/features/shelters/shelter_delete_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe "Shelter Delete", type: :feature do
   it "On shelter show page, click link to delete shelter, return to shelter index, see shelter missing" do
       shelter_1 = Shelter.create(name:'Good Shelter', address: '1 wagon rd.', city: 'Denver', state: 'CO', zipcode: '80207')
 
-      shelter_2 = Shelter.create(name:'Very Good Shelter', address: '32 mountain rd.', city: 'San Diego', state: 'CA', zipcode: '93567')
+      shelter_2 = Shelter.create(name:'Pets Pets Pets', address: '32 mountain rd.', city: 'San Diego', state: 'CA', zipcode: '93567')
 
       visit "shelters/#{shelter_1.id}"
       click_link("Delete Shelter")
       expect(current_path).to eq("/shelters")
 
       expect(page).to_not have_content("Good Shelter")
-      expect(page).to have_content("Very Good Shelter")
+      expect(page).to have_content("Pets Pets Pets")
 
   end
 end

--- a/spec/features/shelters/user_can_update_shelter_from_show_page_spec.rb
+++ b/spec/features/shelters/user_can_update_shelter_from_show_page_spec.rb
@@ -1,5 +1,3 @@
-
-
 require 'rails_helper'
 
 RSpec.describe "Shelter Update", type: :feature do


### PR DESCRIPTION
As a visitor
When I visit a shelter show page
Then I see a link to delete the shelter
When I click the link "Delete Shelter"
Then a 'DELETE' request is sent to '/shelters/:id',
the shelter is deleted,
and I am redirected to the shelter index page where I no longer see this shelter