### PR TITLE
Complete user story 16

### DIFF
--- a/app/views/pets/index_specific.html.erb
+++ b/app/views/pets/index_specific.html.erb
@@ -6,6 +6,7 @@
   <h2><%= pet.name %></h2>
   <h2><%= pet.approximate_age %></h2>
   <h2><%= pet.sex %></h2>
+  <%= link_to "Delete Pet", "/pets/#{pet.id}", method: :delete %>
   <% end %>
 <% end %>
 

--- a/spec/features/pets/pet_index_spec.rb
+++ b/spec/features/pets/pet_index_spec.rb
@@ -32,5 +32,13 @@ RSpec.describe "Pet Index", type: :feature do
     expect(page).to have_link("Update Pet")
     first(:link, 'Update Pet').click
     expect(current_path).to eq("/pets/#{pet_1.id}/edit")
+
+    visit '/pets'
+    expect(page).to have_link("Delete Pet")
+    first(:link, 'Delete Pet').click
+    expect(current_path).to eq("/pets")
+
+    expect(page).to_not have_content(pet_1.name)
+
   end
 end

--- a/spec/features/pets/shelter_pets_index_spec.rb
+++ b/spec/features/pets/shelter_pets_index_spec.rb
@@ -35,5 +35,9 @@ RSpec.describe "Shelter Pet Index", type: :feature do
 
     expect(page).to_not have_content(shelter_2.name)
 
+    expect(page).to have_link("Delete Pet")
+    first(:link, 'Delete Pet').click
+    expect(current_path).to eq("/pets")
+
   end
 end


### PR DESCRIPTION
As a visitor
When I visit the pets index page or a shelter pets index page
Next to every pet, I see a link to delete that pet
When I click the link
I should be taken to the pets index page where I no longer see that pet